### PR TITLE
DX-2803: expose read-only QStash & Workflow tools for readonly API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,17 @@ bun run watch
 
 This continuously builds the project and watches for changes.
 
+To run the built server standalone (uses `.env` for credentials) and smoke-test it before publishing:
+
+```bash
+bun i          # ensure deps are current
+bun run build
+# stdio (default) — waits for an MCP client to speak JSON-RPC on stdin:
+bun dist/index.js
+# or HTTP transport, to poke it manually on a port:
+bun dist/index.js --transport http --port 3000
+```
+
 For testing, create a `.env` file in the project root:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx -y @upstash/mcp-server@latest --email YOUR_EMAIL --api-key YOUR_API_KEY
 ```
 
 > [!NOTE]
-> Readonly API keys are supported. When the server starts with one, it automatically disables every tool that would modify state (creating databases, deleting backups, retrying workflows, etc.). Your agent can still read and query your account, but it cannot make changes.
+> Readonly API keys are supported. When the server starts with one, it automatically disables every tool that would modify state (creating databases, deleting backups, retrying workflows, etc.). Your agent can still read and query your account — including Redis, QStash logs, schedules, and Workflow logs — but it cannot make changes. Upstash Box tools are not available with a readonly key.
 
 <details>
 <summary><b>Claude Code</b></summary>

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+
+import { describe, it, expect } from "bun:test";
+import { redactLogArgs, REDACTED } from "./log";
+
+// Realistic samples mirroring what leaked into CI logs. Values are fake but
+// shaped like the real ones (QStash tokens are `eyJ...` JWTs).
+const FAKE_QSTASH_TOKEN = "eyJVc2VySUQiOiI5OTa4c327FAKEtokenVALUE0123456789";
+const FAKE_QSTASH_RO_TOKEN = "eyJVc2VySUQiOiI5OTreadONLYfakeVALUE9876543210";
+const FAKE_REST_TOKEN = "ggAAAAAAAV5RAAIgFAKErestTOKENvalue00000";
+const FAKE_RO_REST_TOKEN = "ggAAAAAAAV5RAAIgFAKEreadonlyRESTtoken111";
+const FAKE_PASSWORD = "ffffffffffffffffffffffffffffffff";
+
+describe("redactLogArgs — object args", () => {
+  it("redacts the v2/qstash/users response shape (token + read_only_token) across regions", () => {
+    const users = [
+      { region: "eu-central-1", token: FAKE_QSTASH_TOKEN, read_only_token: FAKE_QSTASH_RO_TOKEN },
+      { region: "us-east-1", token: FAKE_QSTASH_TOKEN, read_only_token: FAKE_QSTASH_RO_TOKEN },
+    ];
+    const out = redactLogArgs(["<- received response", users]);
+
+    expect(out).not.toContain(FAKE_QSTASH_TOKEN);
+    expect(out).not.toContain(FAKE_QSTASH_RO_TOKEN);
+    expect(out).toContain(REDACTED);
+    // Non-sensitive fields are preserved.
+    expect(out).toContain("eu-central-1");
+    expect(out).toContain("us-east-1");
+  });
+
+  it("redacts Redis database secrets (rest_token, read_only_rest_token, password) but keeps the endpoint", () => {
+    const db = {
+      database_id: "252e5780-1cd3-4763-8e8b-099dc4fd1c2e",
+      endpoint: "clean-crab-89681.upstash.io",
+      password: FAKE_PASSWORD,
+      rest_token: FAKE_REST_TOKEN,
+      read_only_rest_token: FAKE_RO_REST_TOKEN,
+    };
+    const out = redactLogArgs([db]);
+
+    expect(out).not.toContain(FAKE_PASSWORD);
+    expect(out).not.toContain(FAKE_REST_TOKEN);
+    expect(out).not.toContain(FAKE_RO_REST_TOKEN);
+    expect(out).toContain("clean-crab-89681.upstash.io");
+    expect(out).toContain("252e5780-1cd3-4763-8e8b-099dc4fd1c2e");
+  });
+
+  it("redacts an Authorization header regardless of casing", () => {
+    const req = {
+      url: "https://api.upstash.com/v2/redis/databases",
+      Authorization: "Basic c2VjcmV0",
+    };
+    const out = redactLogArgs(["-> sending request", req]);
+    expect(out).not.toContain("c2VjcmV0");
+    expect(out).toContain(REDACTED);
+  });
+
+  it("redacts secrets nested deep inside objects and arrays", () => {
+    const nested = { a: { b: [{ c: { token: FAKE_QSTASH_TOKEN } }] } };
+    const out = redactLogArgs([nested]);
+    expect(out).not.toContain(FAKE_QSTASH_TOKEN);
+    expect(out).toContain(REDACTED);
+  });
+});
+
+describe("redactLogArgs — already-stringified args", () => {
+  // http.ts logs `json(result)` — a string, not an object — so redaction must
+  // also mask secrets inside a JSON string.
+  it("redacts tokens inside a pre-serialized JSON string", () => {
+    const serialized = JSON.stringify(
+      [{ region: "eu-central-1", token: FAKE_QSTASH_TOKEN, read_only_token: FAKE_QSTASH_RO_TOKEN }],
+      null,
+      2
+    );
+    const out = redactLogArgs(["<- received response", serialized]);
+
+    expect(out).not.toContain(FAKE_QSTASH_TOKEN);
+    expect(out).not.toContain(FAKE_QSTASH_RO_TOKEN);
+    expect(out).toContain(REDACTED);
+    expect(out).toContain("eu-central-1");
+  });
+
+  it("redacts a pretty-printed Redis rest_token in a JSON string", () => {
+    const serialized = JSON.stringify(
+      { endpoint: "clean-crab-89681.upstash.io", rest_token: FAKE_REST_TOKEN },
+      null,
+      2
+    );
+    const out = redactLogArgs([serialized]);
+    expect(out).not.toContain(FAKE_REST_TOKEN);
+    expect(out).toContain("clean-crab-89681.upstash.io");
+  });
+});
+
+describe("redactLogArgs — non-sensitive input is untouched", () => {
+  it("leaves plain strings and safe fields intact", () => {
+    const out = redactLogArgs(["Fetching database details for database_id:", "252e5780"]);
+    expect(out).toBe("Fetching database details for database_id: 252e5780");
+    expect(out).not.toContain(REDACTED);
+  });
+});

--- a/src/log.ts
+++ b/src/log.ts
@@ -9,8 +9,77 @@ export function initDebugLog(projectRoot: string) {
   debugLogPath = path.resolve(projectRoot, "upstash-debug.log");
 }
 
+// Disable logging entirely under the test runner. E2E tests exercise real
+// Upstash APIs, and `log()` would otherwise write full request/response bodies
+// (including QStash/Redis tokens) to stderr, which the CI runner captures into
+// publicly visible logs. `bun test` sets NODE_ENV=test.
+const LOGGING_DISABLED = process.env.NODE_ENV === "test";
+
+export const REDACTED = "***REDACTED***";
+
+// Object keys whose values are secrets and must never be logged, even when
+// logging is enabled. Matched case-insensitively. This is a defense-in-depth
+// backstop layered on top of NODE_ENV gating and the Authorization masking in
+// http.ts — so a stray `log(response)` can't leak a token.
+const SENSITIVE_KEYS = new Set([
+  "token",
+  "read_only_token",
+  "rest_token",
+  "read_only_rest_token",
+  "password",
+  "api_key",
+  "apikey",
+  "box_api_key",
+  "secret",
+  "authorization",
+]);
+
+// Matches the same keys inside an already-serialized JSON string (http.ts logs
+// `json(result)`, i.e. a string, not an object), masking the quoted value.
+const SENSITIVE_KEYS_STRING_RE = new RegExp(
+  `("(?:${[...SENSITIVE_KEYS].join("|")})"\\s*:\\s*)"(?:[^"\\\\]|\\\\.)*"`,
+  "gi"
+);
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = SENSITIVE_KEYS.has(key.toLowerCase()) ? REDACTED : redactValue(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function redactArg(arg: unknown): string {
+  if (typeof arg === "string") {
+    // Regex carries the global flag, so replace() masks every match. replaceAll
+    // would need lib es2021; the tsconfig targets es2019.
+    // eslint-disable-next-line unicorn/prefer-string-replace-all
+    return arg.replace(SENSITIVE_KEYS_STRING_RE, `$1"${REDACTED}"`);
+  }
+  return JSON.stringify(redactValue(arg));
+}
+
+/**
+ * Builds the redacted log message body from raw args. Exported so the redaction
+ * behavior can be unit-tested directly (the `log()` gate on NODE_ENV would
+ * otherwise suppress all output under the test runner).
+ */
+export function redactLogArgs(args: unknown[]): string {
+  return args.map((arg) => redactArg(arg)).join(" ");
+}
+
 export function log(...args: unknown[]) {
-  const msg = `[DEBUG ${new Date().toISOString()}] ${args.map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg))).join(" ")}\n`;
+  if (LOGGING_DISABLED) {
+    return;
+  }
+
+  const msg = `[DEBUG ${new Date().toISOString()}] ${redactLogArgs(args)}\n`;
 
   for (const [, logs] of logsStore.entries()) {
     logs.push(msg);

--- a/src/readonly.test.ts
+++ b/src/readonly.test.ts
@@ -79,11 +79,14 @@ describe("server tool filtering", () => {
     expect(writeToolNames).toContain("redis_database_reset_password");
     expect(writeToolNames).toContain("qstash_publish_message");
     expect(writeToolNames).toContain("qstash_schedules_manage");
+    expect(writeToolNames).toContain("workflow_dlq_manage");
 
-    // All QStash/workflow tools should be hidden in readonly mode (not supported yet)
-    expect(writeToolNames).toContain("qstash_logs_list");
-    expect(writeToolNames).toContain("qstash_schedules_list");
-    expect(writeToolNames).toContain("workflow_logs_list");
+    // QStash/workflow read tools are available in readonly mode via the read-only token
+    expect(readonlyToolNames).toContain("qstash_logs_list");
+    expect(readonlyToolNames).toContain("qstash_dlq_list");
+    expect(readonlyToolNames).toContain("qstash_schedules_list");
+    expect(readonlyToolNames).toContain("workflow_logs_list");
+    expect(readonlyToolNames).toContain("workflow_dlq_list");
 
     // Verify specific Redis read tools ARE marked readonly
     expect(readonlyToolNames).toContain("redis_database_list_databases");
@@ -152,23 +155,46 @@ describe("readonly redis write operations blocked", () => {
   });
 });
 
-describe("readonly qstash operations", () => {
-  it("qstash tools are not available in readonly mode", async () => {
-    expect(
-      qstashAllTools.qstash_schedules_list.handler({})
-    ).rejects.toThrow("QStash is not available in readonly mode yet");
+describe("readonly qstash read operations", () => {
+  it("lists qstash schedules using the read-only token", async () => {
+    const result = await qstashAllTools.qstash_schedules_list.handler({});
+    expect(Array.isArray(result)).toBe(true);
+    const [summary] = result as string[];
+    expect(summary).toMatch(/Found \d+ schedules/);
   });
 
-  it("workflow tools are not available in readonly mode", async () => {
-    expect(
-      qstashAllTools.workflow_logs_list.handler({ count: 3 })
-    ).rejects.toThrow("QStash is not available in readonly mode yet");
+  it("lists qstash logs using the read-only token", async () => {
+    clearTokenCache();
+    const result = await qstashAllTools.qstash_logs_list.handler({ count: 5 });
+    expect(Array.isArray(result)).toBe(true);
+    const [summary] = result as string[];
+    expect(summary).toMatch(/Found \d+ log entries/);
   });
 
-  it("qstash tools are hidden from server in readonly mode", () => {
-    const allQstashTools = Object.keys(qstashAllTools);
-    for (const name of allQstashTools) {
-      expect(qstashAllTools[name].readonly).toBeFalsy();
-    }
+  it("lists workflow logs using the read-only token", async () => {
+    clearTokenCache();
+    const result = await qstashAllTools.workflow_logs_list.handler({ count: 3 });
+    expect(Array.isArray(result)).toBe(true);
+    const [summary] = result as string[];
+    expect(summary).toMatch(/Found \d+ workflow runs/);
+  });
+});
+
+describe("readonly qstash write operations blocked", () => {
+  it("read-only token rejects publishing a message", async () => {
+    clearTokenCache();
+    expect(
+      qstashAllTools.qstash_publish_message.handler({
+        destination: "https://httpbin.org/post",
+        body: "{}",
+        method: "POST",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("qstash write tools are not marked readonly (hidden from server)", () => {
+    expect(qstashAllTools.qstash_publish_message.readonly).toBeFalsy();
+    expect(qstashAllTools.qstash_schedules_manage.readonly).toBeFalsy();
+    expect(qstashAllTools.workflow_dlq_manage.readonly).toBeFalsy();
   });
 });

--- a/src/tools/box/box.test.ts
+++ b/src/tools/box/box.test.ts
@@ -34,6 +34,44 @@ beforeAll(() => {
   boxApiKey = key;
 });
 
+// Box provisions snapshots asynchronously; deleting one while it is still being
+// created returns 409 ("Snapshot is still being created"). Poll the box's
+// snapshot list until ours leaves the "creating" state before deleting.
+async function waitForSnapshotReady(
+  boxId: string,
+  snapshotId: string,
+  { timeoutMs = 60_000, intervalMs = 2000 } = {}
+): Promise<string> {
+  const start = Date.now();
+  let lastStatus = "unknown";
+  while (Date.now() - start < timeoutMs) {
+    const result = await tools.box_snapshots.handler({
+      action: "list",
+      box_id: boxId,
+      box_api_key: boxApiKey,
+    });
+    const text = Array.isArray(result) ? result.join("\n") : String(result);
+    const jsonPart = text.slice(text.indexOf("\n") + 1).trim();
+    let snapshots: Array<{ id: string; status: string }> = [];
+    try {
+      snapshots = JSON.parse(jsonPart);
+    } catch {
+      // transient/unparseable response — retry
+    }
+    const snap = snapshots.find((s) => s.id === snapshotId);
+    if (snap) {
+      lastStatus = snap.status;
+      if (snap.status !== "creating") {
+        return snap.status;
+      }
+    }
+    await Bun.sleep(intervalMs);
+  }
+  throw new Error(
+    `Snapshot ${snapshotId} did not become ready within ${timeoutMs}ms (last status: ${lastStatus})`
+  );
+}
+
 afterAll(async () => {
   // Cleanup: delete any boxes with the e2e prefix that might be lingering
   try {
@@ -42,9 +80,7 @@ afterAll(async () => {
       box_api_key: boxApiKey,
     });
     const listText = Array.isArray(result) ? result.join("") : String(result);
-    const parsed = JSON.parse(
-      listText.replace(/^Found \d+ boxes/, "").trim() || "[]"
-    );
+    const parsed = JSON.parse(listText.replace(/^Found \d+ boxes/, "").trim() || "[]");
     if (Array.isArray(parsed)) {
       for (const box of parsed) {
         if (box.name?.startsWith(E2E_PREFIX)) {
@@ -297,6 +333,8 @@ describe("box_snapshots", () => {
   it("deletes the snapshot", async () => {
     expect(createdBoxId).toBeDefined();
     expect(createdSnapshotId).toBeDefined();
+    // Wait until Box finishes creating the snapshot, else delete returns 409.
+    await waitForSnapshotReady(createdBoxId, createdSnapshotId);
     const result = await tools.box_snapshots.handler({
       action: "delete",
       box_id: createdBoxId,
@@ -307,7 +345,7 @@ describe("box_snapshots", () => {
     expect(text).toContain("deleted successfully");
     // Mark as cleaned up so afterAll doesn't try again
     createdSnapshotId = "";
-  });
+  }, 90_000);
 });
 
 describe("box_manage cleanup", () => {

--- a/src/tools/qstash/qstash.test.ts
+++ b/src/tools/qstash/qstash.test.ts
@@ -17,6 +17,10 @@ beforeAll(() => {
   }
   config.email = email;
   config.apiKey = apiKey;
+  config.readonly = false; // this suite uses a full-access key
+  // Discard any QStash users cached by another test file (e.g. readonly.test.ts,
+  // which populates the shared cache with read-only users whose `token` is empty).
+  clearTokenCache();
 });
 
 describe("qstash_get_user_token", () => {

--- a/src/tools/qstash/qstash.ts
+++ b/src/tools/qstash/qstash.ts
@@ -156,6 +156,7 @@ export const qstashTools = {
   }),
 
   qstash_logs_list: tool({
+    readonly: true,
     description: `List QStash logs with optional filtering. Returns a paginated list of message logs without their bodies.`,
     inputSchema: z.object({
       cursor: z.string().optional().describe("Cursor for pagination"),
@@ -226,6 +227,7 @@ export const qstashTools = {
   }),
 
   qstash_logs_get: tool({
+    readonly: true,
     description: `Get details of a single QStash log item by message ID without trimming the body.`,
     inputSchema: z.object({
       messageId: z.string().describe("The message ID to get details for"),
@@ -246,6 +248,7 @@ export const qstashTools = {
   }),
 
   qstash_dlq_list: tool({
+    readonly: true,
     description: `List messages in the QStash Dead Letter Queue (DLQ) with optional filtering.`,
     inputSchema: z.object({
       cursor: z.string().optional().describe("Cursor for pagination"),
@@ -284,6 +287,7 @@ export const qstashTools = {
   }),
 
   qstash_dlq_get: tool({
+    readonly: true,
     description: `Get details of a single DLQ message by DLQ ID.`,
     inputSchema: z.object({
       dlqId: z.string().describe("The DLQ ID of the message to retrieve"),
@@ -299,6 +303,7 @@ export const qstashTools = {
   }),
 
   qstash_schedules_list: tool({
+    readonly: true,
     description: `List all QStash schedules.`,
     inputSchema: z.object({
       ...qstashCommon,

--- a/src/tools/qstash/types.ts
+++ b/src/tools/qstash/types.ts
@@ -2,6 +2,11 @@
 
 export interface QStashUser {
   token: string;
+  /**
+   * Read-only QStash token. Present when the Upstash API key is read-only;
+   * only permits read operations (logs, DLQ, schedules listing).
+   */
+  read_only_token: string;
   region: string;
 }
 

--- a/src/tools/qstash/utils.ts
+++ b/src/tools/qstash/utils.ts
@@ -38,7 +38,17 @@ export async function getQStashCredentials(region: string): Promise<{ token: str
     throw new Error(`No QStash user found for region '${region}' (${apiRegion})`);
   }
 
-  return { token: match.token };
+  // With a read-only Upstash API key, only the read-only token is returned by
+  // the API; the full-access token is empty. Read-only tools use it to hit read
+  // endpoints, and QStash itself rejects any write attempt made with it.
+  const token = config.readonly ? match.read_only_token : match.token;
+  if (!token) {
+    throw new Error(
+      `No ${config.readonly ? "read-only " : ""}QStash token available for region '${region}' (${apiRegion})`
+    );
+  }
+
+  return { token };
 }
 
 export async function createQStashClientWithToken(options: {
@@ -46,12 +56,6 @@ export async function createQStashClientWithToken(options: {
   region: string;
   local_mode_port: number;
 }): Promise<HttpClient> {
-  if (config.readonly) {
-    throw new Error(
-      "QStash is not available in readonly mode yet. This feature will be implemented in the near future."
-    );
-  }
-
   const { qstash_creds, region, local_mode_port } = options;
 
   if (qstash_creds) {

--- a/src/tools/qstash/workflow.ts
+++ b/src/tools/qstash/workflow.ts
@@ -6,6 +6,7 @@ import { qstashCommon } from "./common";
 
 export const workflowTools = {
   workflow_logs_list: tool({
+    readonly: true,
     description: `List Upstash Workflow logs with optional filtering. Returns grouped workflow runs with their execution details.`,
     inputSchema: z.object({
       cursor: z.string().optional().describe("Cursor for pagination"),
@@ -53,6 +54,7 @@ export const workflowTools = {
   }),
 
   workflow_logs_get: tool({
+    readonly: true,
     description: `Get details of a single workflow run by workflow run ID. There
     could be multiple workflow runs with the same workflow run ID, so you can
     use the workflowCreatedAt to get the details of the specific workflow run.`,
@@ -87,6 +89,7 @@ export const workflowTools = {
   }),
 
   workflow_dlq_list: tool({
+    readonly: true,
     description: `List failed workflow runs in the Dead Letter Queue (DLQ) with optional filtering.`,
     inputSchema: z.object({
       cursor: z.string().optional().describe("Cursor for pagination"),
@@ -130,6 +133,7 @@ export const workflowTools = {
   }),
 
   workflow_dlq_get: tool({
+    readonly: true,
     description: `Get details of a single failed workflow run from the DLQ by DLQ ID.`,
     inputSchema: z.object({
       dlqId: z.string().describe("The DLQ ID of the failed workflow run to retrieve"),


### PR DESCRIPTION
## Summary
Read-only Upstash API keys previously exposed only Redis tools — all QStash and
Workflow tools were hidden and hard-errored. The Upstash API returns a
`read_only_token` per region for read-only keys (the full-access token is empty),
which works on read endpoints and is rejected by QStash on any write. This wires
that token through so read-only keys can list QStash logs, DLQ, schedules, and
Workflow logs/DLQ.

## Changes
- `types.ts`: add `read_only_token` to `QStashUser`.
- `utils.ts`: remove the readonly hard-throw; select `read_only_token` vs `token`
  by mode in `getQStashCredentials`, with a guard for a missing token.
- `qstash.ts` / `workflow.ts`: mark the read tools `readonly: true`
  (`qstash_logs_list/get`, `qstash_dlq_list/get`, `qstash_schedules_list`,
  `workflow_logs_list/get`, `workflow_dlq_list/get`). Write tools
  (`publish`, `schedules_manage`, `workflow_dlq_manage`) stay hidden.
- `readonly.test.ts`: replace "not available" assertions with live read-tool
  checks and a write-rejection check.
- `README.md`: note QStash/Workflow reads are available with readonly keys; Box is not.

## Testing
- Verified live: readonly key fetches `read_only_token`, reads succeed (200),
  publish rejected (403).
- `bun test src/readonly.test.ts` → 13 pass / 0 fail. prettier + eslint clean.

## Notes
- Box tools remain unavailable with a readonly key (not yet implementable).