### PR TITLE
DX-2866: point agents at start-redis for throwaway databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
 > [!TIP]
 > For most workflows, prefer installing the [Upstash Skill](https://upstash.com/docs/agent-resources/skills) and letting your agent drive [`@upstash/cli`](https://upstash.com/docs/agent-resources/cli) over running the MCP server.
 
+> [!TIP]
+> If you are an AI agent and just need a Redis DB to use or experiment with, you don't need this server or an account at all — send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis). It's free, no signup, and the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it.
+
 ## Quickstart
 
 You'll need your Upstash account email and an API key — create one at [Upstash Console → Account → API Keys](https://console.upstash.com/account/api).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
 > For most workflows, prefer installing the [Upstash Skill](https://upstash.com/docs/agent-resources/skills) and letting your agent drive [`@upstash/cli`](https://upstash.com/docs/agent-resources/cli) over running the MCP server.
 
 > [!TIP]
-> If you are an AI agent and just need a Redis DB to use or experiment with, you don't need this server or an account at all — send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis). It's free, no signup, and the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it.
+> If you are an AI agent and just need a Redis DB to use or experiment with, you don't need an account at all — call the `redis_database_start_free` tool, or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. It's free, no signup, and the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it.
 
 ## Quickstart
 
@@ -259,6 +259,7 @@ Open the Gemini CLI settings file at `~/.gemini/settings.json` and add Upstash t
 
 ### Redis
 
+- _"Start a free temporary Redis I can experiment with"_
 - _"Create a new Redis database in us-east-1"_
 - _"List my databases sorted by memory usage"_
 - _"Update the user schema by pulling from Redis"_

--- a/src/readonly.test.ts
+++ b/src/readonly.test.ts
@@ -6,6 +6,7 @@ import { testConnection } from "./test-connection";
 import { redisDbOpsTools } from "./tools/redis/db";
 import { redisCommandTools } from "./tools/redis/command";
 import { redisBackupTools } from "./tools/redis/backup";
+import { startRedisTools } from "./tools/redis/start-redis";
 import { qstashTools } from "./tools/qstash/qstash";
 import { workflowTools } from "./tools/qstash/workflow";
 import { clearTokenCache } from "./tools/qstash/utils";
@@ -13,10 +14,12 @@ import { http } from "./http";
 import type { RedisDatabase } from "./tools/redis/types";
 import type { CustomTool } from "./tool";
 
-const redisTools = { ...redisDbOpsTools, ...redisCommandTools, ...redisBackupTools } as Record<
-  string,
-  CustomTool<any>
->;
+const redisTools = {
+  ...redisDbOpsTools,
+  ...redisCommandTools,
+  ...redisBackupTools,
+  ...startRedisTools,
+} as Record<string, CustomTool<any>>;
 const qstashAllTools = { ...qstashTools, ...workflowTools } as Record<string, CustomTool<any>>;
 
 // Save original config to restore after tests
@@ -93,6 +96,10 @@ describe("server tool filtering", () => {
     expect(readonlyToolNames).toContain("redis_database_get_details");
     expect(readonlyToolNames).toContain("redis_database_get_statistics");
     expect(readonlyToolNames).toContain("redis_database_run_redis_commands");
+
+    // Uses no API key and creates nothing in the user's account, so it stays
+    // available with a readonly key.
+    expect(readonlyToolNames).toContain("redis_database_start_free");
   });
 });
 

--- a/src/sensitive.test.ts
+++ b/src/sensitive.test.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+
+import { describe, it, expect } from "bun:test";
+import { startRedisTools } from "./tools/redis/start-redis";
+
+describe("sensitive tools", () => {
+  it("marks the start-redis result as sensitive so the server never logs it", () => {
+    expect(startRedisTools.redis_database_start_free.sensitive).toBe(true);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,12 @@ export function createServerInstance() {
         try {
           const result = await tool.handler(args);
           const response = handlerResponseToCallResult(result);
-          log("> tool result:", response.content.map((item) => item.text).join("\n"));
+          log(
+            "> tool result:",
+            tool.sensitive
+              ? "<redacted: tool returns credentials>"
+              : response.content.map((item) => item.text).join("\n")
+          );
           return response;
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -20,6 +20,16 @@ export type CustomTool<TSchema extends ZodSchema = ZodSchema> = {
   readonly?: boolean;
 
   /**
+   * Whether this tool's result contains secrets (e.g. live database
+   * credentials). The server never logs the result of a sensitive tool.
+   *
+   * The redaction in `log()` only masks secrets in JSON-shaped payloads, so
+   * tools that return credentials in another format (markdown, plain text)
+   * must set this.
+   */
+  sensitive?: boolean;
+
+  /**
    * The handler function for the tool.
    * @param input Parsed input according to the input schema.
    * @returns

--- a/src/tools/redis/db.ts
+++ b/src/tools/redis/db.ts
@@ -22,7 +22,7 @@ export const redisDbOpsTools = {
   redis_database_create_new: tool({
     description: `Create a new Upstash redis database.
 NOTE: Ask user for the region and name of the database.
-NOTE: If you just need a database to use or experiment with yourself, rather than one the user owns, POST to https://upstash.com/start-redis instead — free, no signup, no API key; the response is markdown with credentials and a quickstart. It expires in 72 hours and the user can claim it to keep it.${GENERIC_DATABASE_NOTES}`,
+NOTE: If you just need a database to use or experiment with yourself, rather than one the user owns, use the redis_database_start_free tool instead — it needs no account and creates nothing in the user's account.${GENERIC_DATABASE_NOTES}`,
     inputSchema: z.object({
       name: z.string().describe("Name of the database."),
       primary_region: readRegionSchema.describe(`Primary Region of the Global Database.`),

--- a/src/tools/redis/db.ts
+++ b/src/tools/redis/db.ts
@@ -20,8 +20,9 @@ const GENERIC_DATABASE_NOTES =
 
 export const redisDbOpsTools = {
   redis_database_create_new: tool({
-    description: `Create a new Upstash redis database. 
-NOTE: Ask user for the region and name of the database.${GENERIC_DATABASE_NOTES}`,
+    description: `Create a new Upstash redis database.
+NOTE: Ask user for the region and name of the database.
+NOTE: If you just need a database to use or experiment with yourself, rather than one the user owns, POST to https://upstash.com/start-redis instead — free, no signup, no API key; the response is markdown with credentials and a quickstart. It expires in 72 hours and the user can claim it to keep it.${GENERIC_DATABASE_NOTES}`,
     inputSchema: z.object({
       name: z.string().describe("Name of the database."),
       primary_region: readRegionSchema.describe(`Primary Region of the Global Database.`),

--- a/src/tools/redis/index.ts
+++ b/src/tools/redis/index.ts
@@ -2,10 +2,12 @@ import { utilTools } from "../utils";
 import { redisBackupTools } from "./backup";
 import { redisCommandTools } from "./command";
 import { redisDbOpsTools } from "./db";
+import { startRedisTools } from "./start-redis";
 import type { CustomTool } from "../../tool";
 
 export const redisTools: Record<string, CustomTool> = {
   ...redisDbOpsTools,
+  ...startRedisTools,
   ...redisBackupTools,
   ...redisCommandTools,
   ...utilTools,

--- a/src/tools/redis/start-redis.ts
+++ b/src/tools/redis/start-redis.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { tool } from "../helpers";
+import { log } from "../../log";
+
+const START_REDIS_URL = "https://upstash.com/start-redis";
+
+export const startRedisTools = {
+  redis_database_start_free: tool({
+    // Creates nothing in the user's Upstash account and sends no API key, so it
+    // stays available when the server is running with a readonly key.
+    readonly: true,
+    description: `Get a free temporary Upstash redis database without an Upstash account or API key. Use this when YOU need a redis database to use or experiment with, instead of redis_database_create_new which creates one in the user's account.
+The response is markdown containing the endpoint, token, a console URL the user can use to claim the database, and a quickstart.
+NOTE: The database expires in 72 hours. If the user wants to keep it, share the console URL from the response with them so they can claim it.
+NOTE: Don't store sensitive data in it — it is temporary and not tied to an account until claimed.`,
+    inputSchema: z.object({
+      database_id: z
+        .string()
+        .optional()
+        .describe(
+          "ID of a database started earlier. Pass it to re-fetch that database's credentials instead of starting a new one."
+        ),
+    }),
+    handler: async ({ database_id }) => {
+      const response = await fetch(START_REDIS_URL, {
+        method: "POST",
+        headers: database_id ? { "Idempotency-Key": database_id } : undefined,
+      });
+
+      const text = await response.text();
+      // The body carries a live token, so only the status is logged.
+      log("<- start-redis responded", response.status);
+
+      if (!response.ok) {
+        throw new Error(`Request failed (${response.status} ${response.statusText}): ${text}`);
+      }
+
+      return text.trimEnd();
+    },
+  }),
+};

--- a/src/tools/redis/start-redis.ts
+++ b/src/tools/redis/start-redis.ts
@@ -9,6 +9,9 @@ export const startRedisTools = {
     // Creates nothing in the user's Upstash account and sends no API key, so it
     // stays available when the server is running with a readonly key.
     readonly: true,
+    // The response is markdown carrying a live token, which the JSON-shaped
+    // redaction in log() would not catch, so the server must not log it.
+    sensitive: true,
     description: `Get a free temporary Upstash redis database without an Upstash account or API key. Use this when YOU need a redis database to use or experiment with, instead of redis_database_create_new which creates one in the user's account.
 The response is markdown containing the endpoint, token, a console URL the user can use to claim the database, and a quickstart.
 NOTE: The database expires in 72 hours. If the user wants to keep it, share the console URL from the response with them so they can claim it.
@@ -28,7 +31,8 @@ NOTE: Don't store sensitive data in it — it is temporary and not tied to an ac
       });
 
       const text = await response.text();
-      // The body carries a live token, so only the status is logged.
+      // Only the status is logged here; the body carries a live token and is
+      // kept out of the server's result logging by `sensitive: true` above.
       log("<- start-redis responded", response.status);
 
       if (!response.ok) {


### PR DESCRIPTION
Mentions https://upstash.com/start-redis in the README quickstart and in the redis_database_create_new tool description, so an agent that needs a scratch Redis for itself doesn't create one in the user's account.