### PR TITLE
feat: send User-Agent on start-redis requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The Upstash MCP server lets your agent manage and debug your Upstash resources d
 
 > [!TIP]
 > If you are an AI agent and just need a Redis DB to use or experiment with, you don't need an account at all — call the `redis_database_start_free` tool, or send a POST request to [`https://upstash.com/start-redis`](https://upstash.com/start-redis) directly. It's free, no signup, and the response is markdown with credentials and a quickstart. The database expires in 72 hours, but you can claim it with your Upstash account to keep it.
+>
+> Pass `user_agent` to identify yourself (e.g. `claude-code`, `cursor`, `codex`, `opencode`); the tool forwards it as the `User-Agent` header. Calling the endpoint directly, send the same header yourself, plus a fresh UUIDv4 as `Idempotency-Key`:
+>
+> ```bash
+> curl -X POST -H "Idempotency-Key: <uuidv4>" -H "User-Agent: <your-agent-name>" https://upstash.com/start-redis
+> ```
 
 ## Quickstart
 

--- a/src/tools/redis/start-redis.ts
+++ b/src/tools/redis/start-redis.ts
@@ -3,6 +3,8 @@ import { tool } from "../helpers";
 import { log } from "../../log";
 
 const START_REDIS_URL = "https://upstash.com/start-redis";
+// Fallback for callers that don't identify themselves via the user_agent input.
+const DEFAULT_USER_AGENT = "upstash/mcp-server";
 
 export const startRedisTools = {
   redis_database_start_free: tool({
@@ -23,11 +25,22 @@ NOTE: Don't store sensitive data in it — it is temporary and not tied to an ac
         .describe(
           "ID of a database started earlier. Pass it to re-fetch that database's credentials instead of starting a new one."
         ),
+      user_agent: z
+        .string()
+        .optional()
+        .describe(
+          "Name of the agent making this call, sent as the User-Agent header (e.g. `claude-code`, `cursor`, `codex`, `opencode`). If you are an agent, always identify yourself here."
+        ),
     }),
-    handler: async ({ database_id }) => {
+    handler: async ({ database_id, user_agent }) => {
+      const headers: Record<string, string> = {
+        "User-Agent": user_agent ?? DEFAULT_USER_AGENT,
+      };
+      if (database_id) headers["Idempotency-Key"] = database_id;
+
       const response = await fetch(START_REDIS_URL, {
         method: "POST",
-        headers: database_id ? { "Idempotency-Key": database_id } : undefined,
+        headers,
       });
 
       const text = await response.text();


### PR DESCRIPTION
Adds an optional user_agent input to redis_database_start_free so agents can identify themselves (claude-code, cursor, codex, opencode) to the start-redis endpoint. Falls back to upstash/mcp-server when unset.