### PR TITLE
DX-2970: make the MCP Registry publish reliable and re-runnable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,12 @@ jobs:
   # `needs: release` gates it on a successful npm publish, so the registry is
   # never updated before the package actually exists on npm. Running as a
   # separate job means a registry hiccup still can't roll back the release.
+  #
+  # The registry validates ownership by fetching
+  # https://registry.npmjs.org/@upstash/mcp-server/<version> and checking its
+  # `mcpName` field, with no retry on its side. npm takes a little while to
+  # serve a freshly published version, so we wait for it to be visible and
+  # retry the publish before giving up.
   # NOTE: the registry CLI + schema are evolving — verify against
   # https://github.com/modelcontextprotocol/registry before relying on this.
   mcp-registry:
@@ -65,14 +71,32 @@ jobs:
     needs: release
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
+    env:
+      MCP_PUBLISHER_VERSION: v1.8.1
     steps:
       - uses: actions/checkout@v4
 
       - name: Sync version into server.json
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           jq --arg v "$VERSION" '.version = $v | (.packages[] |= (.version = $v))' server.json > server.json.tmp
           mv server.json.tmp server.json
+          cat server.json
+
+      - name: Wait for npm to serve the version
+        run: |
+          URL="https://registry.npmjs.org/@upstash/mcp-server/$VERSION"
+          for i in $(seq 1 30); do
+            if curl -fsS "$URL" | jq -e --arg n "$(jq -r .name server.json)" '.mcpName == $n' >/dev/null; then
+              echo "npm serves $VERSION with the expected mcpName"
+              exit 0
+            fi
+            echo "attempt $i: $VERSION not visible on npm yet, retrying in 10s"
+            sleep 10
+          done
+          echo "::error::npm never served $VERSION with mcpName set"
+          exit 1
 
       - name: Install mcp-publisher
         run: |
@@ -82,10 +106,20 @@ jobs:
             aarch64|arm64) ARCH=arm64 ;;
           esac
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --version
 
       - name: Login (GitHub OIDC)
         run: ./mcp-publisher login github-oidc
 
       - name: Publish
-        run: ./mcp-publisher publish
+        run: |
+          for i in 1 2 3; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            echo "publish attempt $i failed, retrying in 20s"
+            sleep 20
+          done
+          echo "::error::mcp-publisher publish failed after 3 attempts"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=upstash&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB1cHN0YXNoL21jcC1zZXJ2ZXJAbGF0ZXN0IiwiLS1lbWFpbCIsIllPVVJfRU1BSUwiLCItLWFwaS1rZXkiLCJZT1VSX0FQSV9LRVkiXX0%3D)
 [<img alt="Install in VS Code" src="https://img.shields.io/badge/Install%20in%20VS%20Code-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white">](https://insiders.vscode.dev/redirect/mcp/install?name=upstash&inputs=%5B%7B%22id%22%3A%22email%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Upstash%20email%22%7D%2C%7B%22id%22%3A%22apiKey%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Upstash%20API%20key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40upstash%2Fmcp-server%40latest%22%2C%22--email%22%2C%22%24%7Binput%3Aemail%7D%22%2C%22--api-key%22%2C%22%24%7Binput%3AapiKey%7D%22%5D%7D)
 
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.upstash%2Fmcp--server-3b82f6)](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.upstash/mcp-server)
+[![Glama](https://img.shields.io/badge/Glama-upstash%2Fmcp--server-0f172a)](https://glama.ai/mcp/servers/upstash/mcp-server)
+[![PulseMCP](https://img.shields.io/badge/PulseMCP-upstash--redis-1f2937)](https://www.pulsemcp.com/servers/upstash-redis)
+
 The Upstash MCP server lets your agent manage and debug your Upstash resources directly, across **Redis**, **QStash**, **Workflow**, and **[Upstash Box](https://upstash.com/docs/box/overall/quickstart)**.
 
 > [!TIP]


### PR DESCRIPTION
Summary

@upstash/mcp-server 0.3.0 is on npm (Aug 24) but the official MCP Registry still lists 0.2.7: the "Publish to MCP Registry" job failed at the Publish step on run 32711807547 with config identical to the successful 0.2.7 run. The registry's npm validator fetches registry.npmjs.org/@upstash/mcp-server/<version> exactly once with no retry, and npm takes a while to serve a just-published version, so the job is racy by design. PulseMCP, Glama and the GitHub/VS Code MCP gallery all scrape this registry.

Changes

- Registry job waits until npm serves the version with the expected mcpName (up to 5 min), retries mcp-publisher publish 3× with backoff, and pins mcp-publisher to v1.8.1 instead of latest.
- workflow_dispatch with a version input runs only the registry job for an existing release — use it to publish 0.3.0 now without cutting a new release.
- README: MCP Registry, Glama, and PulseMCP badges (the Smithery badge was already gone; Smithery doesn't list this server).

Testing

Workflow YAML validated; v1.8.1 publisher asset URL verified (200). The job itself can only be exercised by dispatching it after merge.